### PR TITLE
fix: include react-native-safe-area-context

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -21,7 +21,8 @@
     "react-dom": "^17.0.0",
     "react-native-web": "^0.17.7",
     "react": "17.0.2",
-    "react-native": "0.68.1"
+    "react-native": "0.68.1",
+    "react-native-safe-area-context": "^4.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
## Overview
This PR simply includes `react-native-safe-area-context` which seems to be a requirement for this to run efficiently.